### PR TITLE
A temporary fix for Gitpod's bug #3174

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,6 +16,8 @@ tasks:
     # init: sleep 1 && while [ -f /tmp/.ddev-lock ]; do sleep 1; done
     command: |
       sleep 5
+      docker rm -f $(docker ps -aq) || true
+      docker rmi -f $(docker images -q) || true
       mkcert -install
       ddev config global --instrumentation-opt-in=true
       ddev config global --router-bind-all-interfaces=true


### PR DESCRIPTION
@rfay Thank you so much for your hard work figuring a way to overcome this bug in gitpod - https://github.com/gitpod-io/gitpod/issues/3174

Until that bug gets fixed, this PR deletes all docker images before running `ddev start`. 
When running `ddev start` all images are pulled again with the correct permission.

After Gitpod will fix that bug, this commit can be reverted.
