### PR TITLE
Wait for docker to come up instead of using sleep

### DIFF
--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -48,7 +48,6 @@ services:
 COMPOSEEND
 
 # Misc housekeeping before start
-mkcert -install
 ddev config global --instrumentation-opt-in=true --router-bind-all-interfaces=true
 
 ddev start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,14 +4,19 @@ image:
 # Use 'lock file' to delay running ddev until it is installed
 # https://www.gitpod.io/blog/gitpodify/#running-init-scripts
 tasks:
-  # Wait 5 seconds for `sudo docker-up` to run, before starting ddev 
+  # Wait 5 seconds for `sudo docker-up` to run, before starting ddev
   - name: ddev_run
     command: |
-      sleep 5
+      # Wait for docker to come up before doing gitpod setup (make requires docker)
+      while ! docker ps; do
+        sleep 1
+      done
       .ddev/gitpod-setup-ddev.sh
   - init: composer install
   - name: docker_up
     command: sudo docker-up
+  - name: spare_bash
+    command: bash
 
 
 # Set the following ports public

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,6 +5,8 @@ image:
 # https://www.gitpod.io/blog/gitpodify/#running-init-scripts
 tasks:
   # Wait 5 seconds for `sudo docker-up` to run, before starting ddev
+  - name: docker_up
+    command: sudo docker-up
   - name: ddev_run
     command: |
       # Wait for docker to come up before doing gitpod setup (gitpod-setup requires docker)
@@ -13,10 +15,6 @@ tasks:
       done
       .ddev/gitpod-setup-ddev.sh
   - init: composer install
-  - name: docker_up
-    command: sudo docker-up
-  - name: bash
-    command: bash
 
 
 # Set the following ports public

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,15 +7,15 @@ tasks:
   # Wait 5 seconds for `sudo docker-up` to run, before starting ddev
   - name: ddev_run
     command: |
-      # Wait for docker to come up before doing gitpod setup (make requires docker)
-      while ! docker ps >/dev/null 2&>1; do
+      # Wait for docker to come up before doing gitpod setup (gitpod-setup requires docker)
+      while ! docker ps 2>/dev/null; do
         sleep 1
       done
       .ddev/gitpod-setup-ddev.sh
   - init: composer install
   - name: docker_up
     command: sudo docker-up
-  - name: spare_bash
+  - name: bash
     command: bash
 
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,8 @@ tasks:
     command: sudo docker-up
   - name: ddev_run
     command: |
+      brew upgrade ddev
+      mkcert -install
       # Wait for docker to come up before doing gitpod setup (gitpod-setup requires docker)
       while ! docker ps 2>/dev/null; do
         sleep 1

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
   - name: ddev_run
     command: |
       # Wait for docker to come up before doing gitpod setup (make requires docker)
-      while ! docker ps; do
+      while ! docker ps >/dev/null 2&>1; do
         sleep 1
       done
       .ddev/gitpod-setup-ddev.sh


### PR DESCRIPTION
Currently the .gitpod.yml does a sleep, but it doesn't need to sleep all that time, and it's not even reliable.

Instead, wait until docker is functioning and move on.

This also adds another terminal window so that people have a nice place to start.