### PR TITLE
install a specific version of phpstorm

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,12 +1,12 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-# Install projector and PhpStorm
+# Install projector 
 RUN sudo apt-get -qq update && sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
 RUN pip3 install projector-installer
-# Fragile - will break when they change options
+# Install PhpStorm
 RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance
-RUN printf "8\nY\n3\n" | projector install --no-auto-run
+RUN projector install 'PhpStorm 2020.3.3'
 
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,7 +6,7 @@ RUN sudo apt-get -qq update && sudo apt-get -qq install -y python3 python3-pip l
 RUN pip3 install projector-installer
 # Install PhpStorm
 RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance
-RUN projector install 'PhpStorm 2020.3.3'
+RUN projector install 'PhpStorm 2020.3.3' --no-auto-run
 
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev


### PR DESCRIPTION
resolve https://github.com/shaal/ddev-gitpod/issues/16

With projector-installer v1.1, it is now possible to install a specific version through CLI `projector install 'PhpStorm 2020.3.3'`

@rfay Can you please review this?