### PR TITLE
Preparing for Gitpod's restart workspace bug fix to get into production

### DIFF
--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -6,18 +6,6 @@ set -eu -o pipefail
 
 MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Remove docker containers and specific docker images,
-# because of gitpod bug: https://github.com/gitpod-io/gitpod/issues/3174
-containers_found="$(docker ps -aq)"
-if [[ ! -z "$containers_found" ]]; then
-    docker rm -f $containers_found || true
-fi
-
-images_found="$(docker images | awk '/^drud\/ddev-(webserver|ssh-agent|dbserver)/ { print $3 }')"
-if [[ ! -z "$images_found" ]]; then
-    docker rmi -f $images_found
-fi
-
 # Generate a config.gitpod.yaml that adds the gitpod
 # proxied ports so they're known to ddev.
 shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,8 +2,6 @@ FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
 RUN sudo apt-get -qq update
-# Install latest Docker
-RUN sudo apt-get -qq upgrade docker -y
 # Install Projector 
 RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
 RUN pip3 install projector-installer

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,8 +1,11 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-# Install projector 
-RUN sudo apt-get -qq update && sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6 && sudo apt-get -qq upgrade docker -y
+RUN sudo apt-get -qq update
+# Install latest Docker
+RUN sudo apt-get -qq upgrade docker -y
+# Install Projector 
+RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
 RUN pip3 install projector-installer
 # Install PhpStorm
 RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance
@@ -10,4 +13,3 @@ RUN projector install 'PhpStorm 2020.3.3' --no-auto-run
 
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev
-

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
 # Install projector 
-RUN sudo apt-get -qq update && sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
+RUN sudo apt-get -qq update && sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6 && sudo apt-get -qq upgrade docker -y
 RUN pip3 install projector-installer
 # Install PhpStorm
 RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -12,3 +12,4 @@ RUN projector install 'PhpStorm 2020.3.3' --no-auto-run
 
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,13 +8,13 @@ tasks:
   - init: sudo docker-up &
   # Wait for docker to come up before running ddev
   - init: |
-    brew upgrade ddev
-    mkcert -install
-    # Wait for docker to come up before doing gitpod setup (gitpod-setup requires docker)
-    while ! docker ps 2>/dev/null; do
-      sleep 1
-    done
-    .ddev/gitpod-setup-ddev.sh
+      brew upgrade ddev
+      mkcert -install
+      # Wait for docker to come up before doing gitpod setup (gitpod-setup requires docker)
+      while ! docker ps 2>/dev/null; do
+        sleep 1
+      done
+      .ddev/gitpod-setup-ddev.sh
 
   # Running composer install, docker-up, and start ddev
   - name: composer

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,29 @@
 image:
   file: .gitpod.Dockerfile
 
-# Use 'lock file' to delay running ddev until it is installed
-# https://www.gitpod.io/blog/gitpodify/#running-init-scripts
+# ddev and composer are running as part of the prebuild
+# when workspace gets loaded all docker images are ready
 tasks:
-  # Wait 5 seconds for `sudo docker-up` to run, before starting ddev
-  - name: docker_up
+  - init: composer install
+  - init: sudo docker-up &
+  # Wait for docker to come up before running ddev
+  - init: |
+    brew upgrade ddev
+    mkcert -install
+    # Wait for docker to come up before doing gitpod setup (gitpod-setup requires docker)
+    while ! docker ps 2>/dev/null; do
+      sleep 1
+    done
+    .ddev/gitpod-setup-ddev.sh
+
+  # Running composer install, docker-up, and start ddev
+  - name: composer
+    command: composer install
+  - name: docker-up
+    openMode: split-right
     command: sudo docker-up
   - name: ddev_run
+    openIn: left
     command: |
       brew upgrade ddev
       mkcert -install
@@ -16,7 +32,6 @@ tasks:
         sleep 1
       done
       .ddev/gitpod-setup-ddev.sh
-  - init: composer install
 
 
 # Set the following ports public


### PR DESCRIPTION
At the end of March / beginning of April, the bug fix for https://www.github.com/gitpod-io/gitpod/issues/3174 should be available in production.

This PR runs ddev and composer as part of `init`, to prepare everything in advance, during prebuild, to allow workspace to start much faster.

It then runs ddev and composer again, to apply any changes when a workspace gets opened again.