### PR TITLE
Run ddev during init instead of  command

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       sudo docker-up &
       .ddev/gitpod-setup-ddev.sh
       ddev composer install
-    command: |
+    init: |
       .ddev/gitpod-setup-ddev.sh
       ddev composer install
       gp await-port 8080 && gp preview $(gp url 8080)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ image:
 # when starting a workspace all docker images are ready
 tasks:
   - name: docker-up
-    command: sudo docker-up
+    init: sudo docker-up
   - name: ddev
     prebuild: |
       sudo docker-up &


### PR DESCRIPTION
Run `ddev start` only when the workspace is created.
When workspace times out, and get restored, no need to run `ddev start` again.