### PR TITLE
Use ddev start -y so doesn't stop in prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,7 @@ tasks:
   - name: ddev
     prebuild: |
       sudo docker-up &
+      export DDEV_NONINTERACTIVE=true
       .ddev/gitpod-setup-ddev.sh
       ddev composer install
     command: |


### PR DESCRIPTION
In ddev v1.17, when it detects a "new" ddev version, it will ask if it can do a poweroff.

We obviously don't want that in prebuild.

So set DDEV_NONINTERACTIVE.