### PR TITLE
sudo docker-up is no longer needed

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,11 +4,8 @@ image:
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready
 tasks:
-  - name: docker-up
-    command: sudo docker-up
   - name: ddev
     prebuild: |
-      sudo docker-up &
       export DDEV_NONINTERACTIVE=true
       .ddev/gitpod-setup-ddev.sh
       ddev composer install


### PR DESCRIPTION
See here - https://community.gitpod.io/t/docker-compose-support/1656/15

<a href="https://gitpod.io/#https://github.com/shaal/ddev-gitpod/pull/36"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

