### PR TITLE
Stop using router ports and use webserver port instead

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,13 +3,9 @@ type: drupal9
 docroot: web
 php_version: "7.3"
 webserver_type: nginx-fpm
-router_http_port: "80"
-router_https_port: "443"
-xdebug_enabled: false
-additional_hostnames: []
-additional_fqdns: []
+router_http_port: "8888"
+router_https_port: "8889"
+host_webserver_port: "8080"
 mariadb_version: "10.3"
 mysql_version: ""
-provider: default
-use_dns_when_possible: true
-composer_version: ""
+use_dns_when_possible: false

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -7,4 +7,6 @@ router_http_port: "8888"
 router_https_port: "8889"
 mariadb_version: "10.3"
 mysql_version: ""
-use_dns_when_possible: false
+provider: default
+use_dns_when_possible: true
+composer_version: ""

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,11 +1,10 @@
 name: ddev-gitpod
 type: drupal9
 docroot: web
-php_version: "7.3"
+php_version: "7.4"
 webserver_type: nginx-fpm
 router_http_port: "8888"
 router_https_port: "8889"
-host_webserver_port: "8080"
 mariadb_version: "10.3"
 mysql_version: ""
 use_dns_when_possible: false

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -10,18 +10,6 @@ MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # proxied ports so they're known to ddev.
 shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"
 
-cat <<CONFIGEND > ${MYDIR}/config.gitpod.yaml
-#ddev-gitpod-generated
-router_http_port: 8080
-router_https_port: 8443
-use_dns_when_possible: false
-
-additional_fqdns:
-- 8080-${shortgpurl}
-- 8025-${shortgpurl}
-- 8036-${shortgpurl}
-CONFIGEND
-
 # We need host.docker.internal inside the container,
 # So add it via docker-compose.host-docker-internal.yaml
 hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
@@ -35,7 +23,4 @@ services:
     - "host.docker.internal:${hostip}"
 COMPOSEEND
 
-# Misc housekeeping before start
-ddev config global --instrumentation-opt-in=true --router-bind-all-interfaces=true
-
-ddev start
+ddev start -y

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -21,6 +21,8 @@ services:
   web:
     extra_hosts:
     - "host.docker.internal:${hostip}"
+    ports:
+    - 8080:80
 COMPOSEEND
 
 ddev start -y

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -6,6 +6,20 @@ set -eu -o pipefail
 
 MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# Generate a config.gitpod.yaml that adds the gitpod
+# proxied ports so they're known to ddev.
+shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"
+
+cat <<CONFIGEND > ${MYDIR}/config.gitpod.yaml
+#ddev-gitpod-generated
+use_dns_when_possible: false
+
+additional_fqdns:
+- 8888-${shortgpurl}
+- 8025-${shortgpurl}
+- 8036-${shortgpurl}
+CONFIGEND
+
 # We need host.docker.internal inside the container,
 # So add it via docker-compose.host-docker-internal.yaml
 hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
@@ -17,8 +31,14 @@ services:
   web:
     extra_hosts:
     - "host.docker.internal:${hostip}"
+    # This adds 8080 on the host (bound on all interfaces)
+    # It goes directly to the web container without
+    # ddev-nginx
     ports:
     - 8080:80
 COMPOSEEND
+
+# Misc housekeeping before start
+ddev config global --router-bind-all-interfaces
 
 yes | ddev start

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -6,10 +6,6 @@ set -eu -o pipefail
 
 MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Generate a config.gitpod.yaml that adds the gitpod
-# proxied ports so they're known to ddev.
-shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"
-
 # We need host.docker.internal inside the container,
 # So add it via docker-compose.host-docker-internal.yaml
 hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
@@ -25,4 +21,4 @@ services:
     - 8080:80
 COMPOSEEND
 
-ddev start -y
+yes | ddev start

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,7 +3,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN sudo apt-get -qq update
 # Install required libraries for Projector + PhpStorm
-RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
+RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6 telnet netcat
 # Install Projector
 RUN pip3 install projector-installer
 # Install PhpStorm

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst
 RUN pip3 install projector-installer
 # Install PhpStorm
 RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance
-RUN projector install 'PhpStorm 2021.1' --no-auto-run
+RUN projector install 'PhpStorm 2021.1.3' --no-auto-run
 
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev && mkcert -install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,6 @@ ports:
     visibility: private
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
-    onOpen: ignore
     visibility: private
   # Currently un-notified and unsupported mailhog http port
   - port: 8025

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,30 +17,40 @@ tasks:
 
 # Set the following ports public
 ports:
+  # Used by projector
   - port: 6942
     onOpen: ignore
+    visibility: private
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
+    visibility: private
   # Currently un-notified and unsupported mailhog http port
   - port: 8025
     onOpen: ignore
+    visibility: private
   # Currently un-notified and unsupported mailhog https port
   - port: 8026
     onOpen: ignore
+    visibility: private
   # Currently un-notified and unsupported phpmyadmin http port
   - port: 8036
     onOpen: ignore
+    visibility: private
   # Currently un-notified and unsupported phpmyadmin https port
   - port: 8037
     onOpen: ignore
+    visibility: private
   # router http port that we're ignoring.
   - port: 8888
     onOpen: ignore
+    visibility: private
   # router https port that we're ignoring.
   - port: 8889
     onOpen: ignore
-  # PhpStorm
+    visibility: private
+  # projector port
   - port: 9999
+    visibility: private
 
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,21 +19,28 @@ tasks:
 ports:
   - port: 6942
     onOpen: ignore
+  # Direct-connect ddev-webserver port that is the main port
   - port: 8080
+  # Currently un-notified and unsupported mailhog http port
   - port: 8025
     onOpen: ignore
+  # Currently un-notified and unsupported mailhog https port
   - port: 8026
     onOpen: ignore
+  # Currently un-notified and unsupported phpmyadmin http port
   - port: 8036
     onOpen: ignore
+  # Currently un-notified and unsupported phpmyadmin https port
   - port: 8037
     onOpen: ignore
-  - port: 8443
-    onOpen: ignore
+  # router http port that we're ignoring.
   - port: 8888
     onOpen: ignore
+  # router https port that we're ignoring.
   - port: 8889
     onOpen: ignore
+  # PhpStorm
+  - port: 9999
 
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,7 +30,10 @@ ports:
     onOpen: ignore
   - port: 8443
     onOpen: ignore
-  - port: 9999
+  - port: 8888
+    onOpen: ignore
+  - port: 8889
+    onOpen: ignore
 
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,7 @@ ports:
     visibility: private
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
-    onOpen: open-preview
+    onOpen: ignore
     visibility: private
   # Currently un-notified and unsupported mailhog http port
   - port: 8025

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,6 @@ tasks:
       ddev composer install
       gp await-port 8080 && gp preview $(gp url 8080)
 
-# Set the following ports public
 ports:
   # Used by projector
   - port: 6942

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,8 +22,8 @@ ports:
     visibility: private
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
-    visibility: private
     onOpen: open-preview
+    visibility: private
   # Currently un-notified and unsupported mailhog http port
   - port: 8025
     onOpen: ignore
@@ -50,11 +50,12 @@ ports:
     visibility: private
   # xdebug port
   - port: 9000
+    onOpen: ignore
     visibility: private
   # projector port
   - port: 9999
-    visibility: private
     onOpen: open-preview
+    visibility: private
 
 github:
   prebuilds:

--- a/composer.lock
+++ b/composer.lock
@@ -1276,16 +1276,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.1.9",
+            "version": "9.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "2c649d5807f08f8c7945d1c6ffb4bb21d5c7849a"
+                "reference": "7fa70eb78addcef8ad704edad9fa73337b8cdab5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/2c649d5807f08f8c7945d1c6ffb4bb21d5c7849a",
-                "reference": "2c649d5807f08f8c7945d1c6ffb4bb21d5c7849a",
+                "url": "https://api.github.com/repos/drupal/core/zipball/7fa70eb78addcef8ad704edad9fa73337b8cdab5",
+                "reference": "7fa70eb78addcef8ad704edad9fa73337b8cdab5",
                 "shasum": ""
             },
             "require": {
@@ -1522,13 +1522,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.1.9"
+                "source": "https://github.com/drupal/core/tree/9.1.10"
             },
-            "time": "2021-05-25T09:18:28+00:00"
+            "time": "2021-06-04T17:28:30+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.1.9",
+            "version": "9.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -1572,13 +1572,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.2.0-beta1"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.2.0-beta3"
             },
             "time": "2020-08-07T22:30:13+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "9.1.9",
+            "version": "9.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
@@ -1613,22 +1613,22 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-project-message/tree/9.2.0-beta1"
+                "source": "https://github.com/drupal/core-project-message/tree/9.2.0-beta3"
             },
             "time": "2020-09-14T13:40:36+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.1.9",
+            "version": "9.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "c29e4707ba567b7b80b86a8fa6aea0d0e50967b0"
+                "reference": "cf3bc76f7f15a77b6655d74a535ed6e704da9490"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/c29e4707ba567b7b80b86a8fa6aea0d0e50967b0",
-                "reference": "c29e4707ba567b7b80b86a8fa6aea0d0e50967b0",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/cf3bc76f7f15a77b6655d74a535ed6e704da9490",
+                "reference": "cf3bc76f7f15a77b6655d74a535ed6e704da9490",
                 "shasum": ""
             },
             "require": {
@@ -1637,7 +1637,7 @@
                 "doctrine/annotations": "1.11.1",
                 "doctrine/lexer": "1.2.1",
                 "doctrine/reflection": "1.2.2",
-                "drupal/core": "9.1.9",
+                "drupal/core": "9.1.10",
                 "egulias/email-validator": "2.1.22",
                 "guzzlehttp/guzzle": "6.5.5",
                 "guzzlehttp/promises": "1.4.0",
@@ -1698,9 +1698,9 @@
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/9.1.9"
+                "source": "https://github.com/drupal/core-recommended/tree/9.1.10"
             },
-            "time": "2021-05-25T09:18:28+00:00"
+            "time": "2021-06-04T17:28:30+00:00"
         },
         {
             "name": "drush/drush",
@@ -4009,16 +4009,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.22",
+            "version": "v4.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "f0f06656a18304cdeacb2c4c0113a2b78a2b4c2a"
+                "reference": "2d926ebd76f52352deb3c9577d8c1d4b96eae429"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f0f06656a18304cdeacb2c4c0113a2b78a2b4c2a",
-                "reference": "f0f06656a18304cdeacb2c4c0113a2b78a2b4c2a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2d926ebd76f52352deb3c9577d8c1d4b96eae429",
+                "reference": "2d926ebd76f52352deb3c9577d8c1d4b96eae429",
                 "shasum": ""
             },
             "require": {
@@ -4051,7 +4051,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v4.4.22"
+                "source": "https://github.com/symfony/filesystem/tree/v4.4.25"
             },
             "funding": [
                 {
@@ -4067,20 +4067,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T10:24:12+00:00"
+            "time": "2021-05-26T17:30:55+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.9",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d"
+                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
-                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
                 "shasum": ""
             },
             "require": {
@@ -4112,7 +4112,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.9"
+                "source": "https://github.com/symfony/finder/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -4128,7 +4128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T13:07:46+00:00"
+            "time": "2021-05-26T12:52:38+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -4868,16 +4868,16 @@
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
                 "shasum": ""
             },
             "require": {
@@ -4886,7 +4886,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4924,7 +4924,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -4940,20 +4940,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -4962,7 +4962,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5003,7 +5003,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -5019,7 +5019,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -6234,5 +6234,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Since Gitpod is providing the functionality of ddev-router, let's just not use the router ports, and use the ddev-webserver port explicitly.

<a href="https://gitpod.io/#https://github.com/shaal/ddev-gitpod/pull/51"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

