### PR TITLE
Add experimentalNetwork, which makes docker host gateway work

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 image:
   file: .gitpod.Dockerfile
+experimentalNetwork: true
 
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready


### PR DESCRIPTION
Gitpod added `experimentalNetwork: true` to their system a while ago, and it makes normal network inspection work (to find host.gateway.internal). 

This just adds that to .gitpod.yml

It will be required in the next version of ddev, coming soon.

See
* https://github.com/gitpod-io/gitpod/issues/6446
* https://github.com/gitpod-io/gitpod/pull/6409

<a href="https://gitpod.io/#https://github.com/shaal/ddev-gitpod/pull/101"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

